### PR TITLE
TSDK-251 Add support for different Topl networks

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,5 @@
+OrganizeImports {
+  groups = ["re:javax?\\.", "scala.", "*"]
+  removeUnused = true
+}
+

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,11 @@ def versionFmt(out: sbtdynver.GitDescribeOutput): String = {
 
 def fallbackVersion(d: java.util.Date): String = s"HEAD-${sbtdynver.DynVer timestamp d}"
 
+scalacOptions += "-Ywarn-unused"
 
+semanticdbEnabled := true
+
+semanticdbVersion := scalafixSemanticdb.revision
 
 lazy val mavenPublishSettings = List(
   organization := "co.topl",
@@ -56,9 +60,10 @@ lazy val root = (project in file("."))
   .settings(
     name := "bifrost-daml-broker",
     scalaVersion := "2.13.8",
-    libraryDependencies += scalaTest % Test,
     libraryDependencies += brambl,
     libraryDependencies += bramblCommon,
     libraryDependencies += toplDaml,
-    libraryDependencies += slf4j
+    libraryDependencies += slf4j,
+    libraryDependencies += scopt,
+    libraryDependencies += munit
   ).enablePlugins(DockerPlugin, JavaAppPackaging)

--- a/microsite/docs/reference/runtime.md
+++ b/microsite/docs/reference/runtime.md
@@ -4,30 +4,52 @@ sidebar_position: 2
 
 # Command Line Reference
 
-Shows the list of parameters available to start the broker.
+We intruduce the list of parameters available to start the broker.
 
 ## Usage
 
-The following parameters are needed to launch the broker.
+We need the following parameters to launch the broker.
 
 ### Example
 
 ```bash
-bifrost-daml-broker <HOST> <PORT> <KEYFILENAME> <KEYFILEPASSWORD>
+Usage: bifrost-daml-broker [options]
+
+  -n, --topl-network <value>
+                           the Topl network to connect to, one of: main, valhalla, and private
+  -u, --topl-uri <value>   the URI of the Topl network to connect to, for example https://127.0.0.1/
+  -a, --topl-api-key <value>
+                           the API key for the Topl network
+  -h, --daml-host <value>  the host of the ledger, for example localhost
+  -p, --daml-port <value>  the port where the ledger is listening, for example 6865
+  -k, --keyfile <value>    the file that contains the operator key, for example keyfile.json
+  -w, --password <value>   the password for the keyfile
 ```
 
-### HOST
+### -n, --topl-network <value\>
 
-The host where the DAML participant node is hosted, for example, `localhost`.
+The Topl network to connect to, potential values are: main, valhalla, and private.
 
-### PORT
+### -u, --topl-uri <value\>
 
-The port of the host where the DAML partticipant node is hosted, for example `6865`.
+The URI of the Topl network to connect to, for example https://127.0.0.1/.
 
-### KEYFILENAME
+### -a, --topl-api-key <value\>
 
-The filename that contains the key that the broker uses for signing, for example `keyfile.json`.
+The API key for the Topl network.
 
-### KEYFILEPASSWORD
+### -h, --daml-host <value\>
 
-The password for the key file used for signing, for example `test`.
+The host of the ledger, for example localhost.
+
+### -p, --daml-port <value\>
+
+The port where the ledger is listening, for example 6865.
+
+### -k, --keyfile <value\>
+
+The file that contains the operator key, for example keyfile.json. This parameter is optional. When we do not include this parameter the broker will not sign transactions as operator.
+
+### -w, --password <value\>
+
+The password for the key file. This is only required when a key file is present.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,10 +5,11 @@ object Dependencies {
   lazy val toplOrg = "co.topl"
 
   lazy val bramblVersion = "1.10.2"
-  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.11"
   lazy val brambl = toplOrg %% "brambl" % bramblVersion
   lazy val bramblCommon = toplOrg %% "common" % bramblVersion
   lazy val catEffects = "org.typelevel" %% "cats-effect" % "3.3.12"
   lazy val toplDaml = toplOrg % "daml-bifrost-module" % "0.1.0"
   lazy val slf4j = "org.slf4j" % "slf4j-simple" % "2.0.5"
+  lazy val scopt = "com.github.scopt" %% "scopt" % "4.0.1"
+  lazy val munit = "org.scalameta" %% "munit" % "0.7.29" % Test,
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.11")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.9")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.4")

--- a/src/main/scala/broker/AssetMintingProcessorRegistrationModule.scala
+++ b/src/main/scala/broker/AssetMintingProcessorRegistrationModule.scala
@@ -23,8 +23,8 @@ trait AssetMintingProcessorRegistrationModule {
           damlAppContext,
           toplContext,
           3000,
-          (x, y) => true,
-          t => true
+          (_, _) => true,
+          _ => true
         )
       )
       _ <- IO(transactions.forEach(transferProcessor.processTransaction))
@@ -47,8 +47,8 @@ trait AssetMintingProcessorRegistrationModule {
             i = i + 1
             i.toString()
           },
-          (x, y) => true,
-          t => true
+          (_, _) => true,
+          _ => true
         )
       )
       _ <- IO(transactions.forEach(transferProcessor.processTransaction))
@@ -70,8 +70,8 @@ trait AssetMintingProcessorRegistrationModule {
           toplContext,
           keyfile,
           password,
-          (x: UnsignedAssetMinting, y: UnsignedAssetMinting.ContractId) => true,
-          (t: Throwable) => true
+          (_: UnsignedAssetMinting, _: UnsignedAssetMinting.ContractId) => true,
+          (_: Throwable) => true
         )
       )
       _ <- IO(transactions.forEach(transferProcessor.processTransaction))

--- a/src/main/scala/broker/AssetTransferProcessorRegistrationModule.scala
+++ b/src/main/scala/broker/AssetTransferProcessorRegistrationModule.scala
@@ -1,13 +1,12 @@
 package broker
 
-import io.reactivex.Flowable
+import cats.effect.IO
 import co.topl.daml.DamlAppContext
 import co.topl.daml.ToplContext
-import com.daml.ledger.javaapi.data.Transaction
-import cats.effect.IO
-import co.topl.daml.assets.processors.AssetTransferRequestProcessor
-import co.topl.daml.assets.processors.SignedAssetTransferRequestProcessor
 import co.topl.daml.assets.processors.AssetTransferRequestEd25519Processor
+import co.topl.daml.assets.processors.SignedAssetTransferRequestProcessor
+import com.daml.ledger.javaapi.data.Transaction
+import io.reactivex.Flowable
 
 trait AssetTransferProcessorRegistrationModule {
 

--- a/src/main/scala/broker/AssetTransferProcessorRegistrationModule.scala
+++ b/src/main/scala/broker/AssetTransferProcessorRegistrationModule.scala
@@ -21,8 +21,8 @@ trait AssetTransferProcessorRegistrationModule {
           damlAppContext,
           toplContext,
           3000,
-          (x, y) => true,
-          t => true
+          (_, _) => true,
+          _ => true
         )
       )
       _ <- IO(transactions.forEach(transferProcessor.processTransaction))
@@ -45,8 +45,8 @@ trait AssetTransferProcessorRegistrationModule {
             i = i + 1
             i.toString()
           },
-          (x, y) => true,
-          t => true
+          (_, _) => true,
+          _ => true
         )
       )
       _ <- IO(transactions.forEach(transferProcessor.processTransaction))

--- a/src/main/scala/broker/BalanceProcessorModule.scala
+++ b/src/main/scala/broker/BalanceProcessorModule.scala
@@ -1,15 +1,11 @@
 package broker
 
-import io.reactivex.Flowable
+import cats.effect.IO
 import co.topl.daml.DamlAppContext
 import co.topl.daml.ToplContext
-import com.daml.ledger.javaapi.data.Transaction
-import cats.effect.IO
-import co.topl.daml.assets.processors.AssetTransferRequestProcessor
-import co.topl.daml.assets.processors.SignedAssetTransferRequestProcessor
-import co.topl.daml.assets.processors.AssetTransferRequestEd25519Processor
-import co.topl.daml.api.model.topl.asset.AssetBalanceRequest
 import co.topl.daml.assets.processors.AssetBalanceRequestProcessor
+import com.daml.ledger.javaapi.data.Transaction
+import io.reactivex.Flowable
 
 trait BalanceProcessorModule {
 

--- a/src/main/scala/broker/BalanceProcessorModule.scala
+++ b/src/main/scala/broker/BalanceProcessorModule.scala
@@ -20,8 +20,8 @@ trait BalanceProcessorModule {
           damlAppContext,
           toplContext,
           3000,
-          (x, y) => true,
-          t => true
+          (_, _) => true,
+          _ => true
         )
       )
       _ <- IO(transactions.forEach(transferProcessor.processTransaction))

--- a/src/main/scala/broker/BrokerMain.scala
+++ b/src/main/scala/broker/BrokerMain.scala
@@ -1,58 +1,45 @@
 package broker
 
+import java.util.Collections
+
+import akka.actor.ActorSystem
+import cats.data.Validated
+import cats.effect.ExitCode
+import cats.effect.IO
 import cats.effect.IOApp
-import cats.effect.{ExitCode, IO}
-import com.daml.ledger.rxjava.DamlLedgerClient
-import com.daml.ledger.rxjava.UserManagementClient
-import com.daml.ledger.javaapi.data.GetUserRequest
-import akka.http.scaladsl.model.Uri
 import co.topl.daml.DamlAppContext
 import co.topl.daml.ToplContext
-import akka.actor.ActorSystem
-import co.topl.client.Provider
-import co.topl.daml.polys.processors.TransferRequestProcessor
-import com.daml.ledger.javaapi.data.LedgerOffset
 import com.daml.ledger.javaapi.data.FiltersByParty
-import java.util.Collections
+import com.daml.ledger.javaapi.data.GetUserRequest
+import com.daml.ledger.javaapi.data.LedgerOffset
 import com.daml.ledger.javaapi.data.NoFilter
-import io.reactivex.Flowable
-import com.daml.ledger.javaapi.data.Transaction
-import co.topl.daml.polys.processors.SignedTransferProcessor
-import co.topl.daml.polys.processors.UnsignedTransferProcessor
-import co.topl.daml.api.model.topl.transfer.UnsignedTransfer
-import co.topl.daml.assets.processors.AssetMintingRequestProcessor
-import co.topl.daml.assets.processors.SignedMintingRequestProcessor
-import co.topl.daml.assets.processors.UnsignedMintingRequestProcessor
-import co.topl.daml.api.model.topl.asset.UnsignedAssetMinting
-import co.topl.daml.assets.processors.AssetTransferRequestProcessor
-import co.topl.daml.assets.processors.SignedAssetTransferRequestProcessor
+import com.daml.ledger.rxjava.DamlLedgerClient
+import com.daml.ledger.rxjava.UserManagementClient
+import scopt.OParser
 
 object BrokerMain
     extends IOApp
     with PolyProcessorRegistrationModule
     with AssetTransferProcessorRegistrationModule
     with AssetMintingProcessorRegistrationModule
-    with BalanceProcessorModule {
+    with BalanceProcessorModule
+    with ParameterProcessorModule {
 
-  val EXPECTED_ARG_COUNT = 4;
   val OPERATOR_USER = "public";
   val APP_ID = "toplBrokerApp";
 
-  override def run(args: List[String]): IO[ExitCode] =
+
+  def runWithParams(paramConfig: CLIParamConfigValidatedInput) = {
     (for {
-      tuple <- getArgs(args)
-      (host, port, keyfile, password) = tuple
-      client <- createClient(host, port)
+      client <- createClient(paramConfig.damlHost, paramConfig.damlPort)
       _ <- connect(client)
       userManagementClient <- getUserManagementClient(client)
       operatorParty <- getOperatorParty(userManagementClient)
-      _ <- IO.println("The operator party is: " + operatorParty)
-      uri <- IO(Uri("http://127.0.0.1:9085/"))
       damlAppContext <- IO(new DamlAppContext(APP_ID, operatorParty, client))
       toplContext <- IO(
         new ToplContext(
           ActorSystem(),
-          new Provider.PrivateTestNet(uri, "")
+          paramConfig.provider
         )
       )
       transactions <- getTransactions(client, operatorParty)
@@ -60,11 +47,16 @@ object BrokerMain
       implicit val damlAppContextImpl = damlAppContext
       implicit val toplContextImpl = toplContext
       implicit val transactionsImpl = transactions
+
       for {
         _ <- registerTransferProcessor()
         _ <- registerSignedTransferProcessor()
-        _ <- registerUnsignedTransferProcessor(keyfile, password)
-        _ <- registerUnsignedMintingProcessor(keyfile, password)
+        _ <- paramConfig.keyfileAndPassword
+          .map(e => registerUnsignedTransferProcessor(e._1.getPath(), e._2))
+          .getOrElse(IO.unit)
+        _ <- paramConfig.keyfileAndPassword
+          .map(e => registerUnsignedMintingProcessor(e._1.getPath(), e._2))
+          .getOrElse(IO.unit)
         _ <- registerMintingRequestProcessor()
         _ <- registerAssetTransferRequestProcessor()
         _ <- registerSignedMintingRequestProcessor()
@@ -73,6 +65,23 @@ object BrokerMain
         _ <- IO.never[Unit]
       } yield ExitCode.Success
     }).flatten
+  }
+
+  override def run(args: List[String]): IO[ExitCode] = {
+    OParser.parse(parser, args, CLIParamConfigInput()) match {
+      case Some(paramConfig) =>
+        validateParams(paramConfig) match {
+          case Validated.Valid(validatedInput) =>
+            runWithParams(validatedInput)
+          case Validated.Invalid(errors) =>
+            IO.println("Invalid parameters\n" + errors.toList.mkString("\n")) *>
+              IO.pure(ExitCode.Error)
+        }
+      case None =>
+        IO.pure(ExitCode.Error)
+    }
+
+  }
 
   def getTransactions(client: DamlLedgerClient, operatorParty: String) = IO(
     client
@@ -103,16 +112,5 @@ object BrokerMain
 
   def connect(client: DamlLedgerClient) = IO(client.connect())
 
-  def getArgs(args: List[String]) = if (args.size != EXPECTED_ARG_COUNT) {
-    for {
-      _ <- IO.print("Usage: HOST PORT KEYFILENAME KEYFILEPASSWORD")
-    } yield throw new IllegalArgumentException
-  } else {
-    val host = args(0)
-    val port = Integer.parseInt(args(1))
-    val keyfile = args(2)
-    val password = args(3)
-    IO.pure((host, port, keyfile, password))
-  }
 
 }

--- a/src/main/scala/broker/BrokerMain.scala
+++ b/src/main/scala/broker/BrokerMain.scala
@@ -74,7 +74,7 @@ object BrokerMain
           case Validated.Valid(validatedInput) =>
             runWithParams(validatedInput)
           case Validated.Invalid(errors) =>
-            IO.println("Invalid parameters\n" + errors.toList.mkString("\n")) *>
+            IO.println("The broker was launched with Invalid parameters:\n" + errors.toList.map(s => " - " + s).mkString("\n")) *>
               IO.pure(ExitCode.Error)
         }
       case None =>

--- a/src/main/scala/broker/BrokerMain.scala
+++ b/src/main/scala/broker/BrokerMain.scala
@@ -74,7 +74,7 @@ object BrokerMain
           case Validated.Valid(validatedInput) =>
             runWithParams(validatedInput)
           case Validated.Invalid(errors) =>
-            IO.println("The broker was launched with Invalid parameters:\n" + errors.toList.map(s => " - " + s).mkString("\n")) *>
+            IO.println("The broker was launched with invalid parameters:\n" + errors.toList.map(s => " - " + s).mkString("\n")) *>
               IO.pure(ExitCode.Error)
         }
       case None =>

--- a/src/main/scala/broker/CLIParamConfig.scala
+++ b/src/main/scala/broker/CLIParamConfig.scala
@@ -1,0 +1,22 @@
+package broker
+
+import java.io.File
+
+import co.topl.client.Provider
+
+case class CLIParamConfigInput(
+    networkType: String = "",
+    networkUri: String = "",
+    someApiKey: Option[String] = None,
+    damlHost: String = "",
+    damlPort: Int = 0,
+    someKeyfile: Option[File] = None,
+    somePassword: Option[String] = None
+)
+
+case class CLIParamConfigValidatedInput(
+    provider: Provider,
+    damlHost: String,
+    damlPort: Int,
+    keyfileAndPassword: Option[(File, String)]
+)

--- a/src/main/scala/broker/ParameterProcessorModule.scala
+++ b/src/main/scala/broker/ParameterProcessorModule.scala
@@ -19,7 +19,7 @@ trait ParameterProcessorModule {
       programName("bifrost-daml-broker"),
       head("bifrost-daml-broker", "0.2"),
       opt[String]('n', "topl-network")
-        .action((x, c) => c.copy(networkUri = x))
+        .action((x, c) => c.copy(networkType = x))
         .text(
           "the Topl network to connect to, one of: main, valhalla, and private"
         ),

--- a/src/main/scala/broker/ParameterProcessorModule.scala
+++ b/src/main/scala/broker/ParameterProcessorModule.scala
@@ -17,7 +17,7 @@ trait ParameterProcessorModule {
     import builder._
     OParser.sequence(
       programName("bifrost-daml-broker"),
-      head("bifrost-daml-broker", "0.1"),
+      head("bifrost-daml-broker", "0.2"),
       opt[String]('n', "topl-network")
         .action((x, c) => c.copy(networkUri = x))
         .text(
@@ -25,19 +25,19 @@ trait ParameterProcessorModule {
         ),
       opt[String]('u', "topl-uri")
         .action((x, c) => c.copy(networkUri = x))
-        .text("the URI of the Topl network to connect to"),
+        .text("the URI of the Topl network to connect to, for example https://127.0.0.1/"),
       opt[Option[String]]('a', "topl-api-key")
         .action((x, c) => c.copy(someApiKey = x))
         .text("the API key for the Topl network"),
       opt[String]('h', "daml-host")
         .action((x, c) => c.copy(damlHost = x))
-        .text("the host of the ledger"),
+        .text("the host of the ledger, for example localhost"),
       opt[Int]('p', "daml-port")
         .action((x, c) => c.copy(damlPort = x))
-        .text("the port where the ledger is listening"),
+        .text("the port where the ledger is listening, for example 6865"),
       opt[Option[File]]('k', "keyfile")
         .action((x, c) => c.copy(someKeyfile = x))
-        .text("the file that contains the operator key"),
+        .text("the file that contains the operator key, for example keyfile.json"),
       opt[Option[String]]('w', "password")
         .action((x, c) => c.copy(somePassword = x))
         .text("the password for the keyfile")

--- a/src/main/scala/broker/ParameterProcessorModule.scala
+++ b/src/main/scala/broker/ParameterProcessorModule.scala
@@ -1,0 +1,146 @@
+package broker
+
+import java.io.File
+
+import akka.http.scaladsl.model.Uri
+import cats.data.Validated
+import cats.data.ValidatedNel
+import co.topl.client.Provider
+import scopt.OParser
+import com.google.common.net.InetAddresses
+import com.google.common.net.InternetDomainName
+
+trait ParameterProcessorModule {
+
+  val builder = OParser.builder[CLIParamConfigInput]
+  val parser = {
+    import builder._
+    OParser.sequence(
+      programName("bifrost-daml-broker"),
+      head("bifrost-daml-broker", "0.1"),
+      opt[String]('n', "topl-network")
+        .action((x, c) => c.copy(networkUri = x))
+        .text(
+          "the Topl network to connect to, one of: main, valhalla, and private"
+        ),
+      opt[String]('u', "topl-uri")
+        .action((x, c) => c.copy(networkUri = x))
+        .text("the URI of the Topl network to connect to"),
+      opt[Option[String]]('a', "topl-api-key")
+        .action((x, c) => c.copy(someApiKey = x))
+        .text("the API key for the Topl network"),
+      opt[String]('h', "daml-host")
+        .action((x, c) => c.copy(damlHost = x))
+        .text("the host of the ledger"),
+      opt[Int]('p', "daml-port")
+        .action((x, c) => c.copy(damlPort = x))
+        .text("the port where the ledger is listening"),
+      opt[Option[File]]('k', "keyfile")
+        .action((x, c) => c.copy(someKeyfile = x))
+        .text("the file that contains the operator key"),
+      opt[Option[String]]('w', "password")
+        .action((x, c) => c.copy(somePassword = x))
+        .text("the password for the keyfile")
+    )
+  }
+
+  def validateParams(
+      paramConfig: CLIParamConfigInput
+  ): ValidatedNel[String, CLIParamConfigValidatedInput] = {
+    import cats.implicits._
+    (
+      (
+        validateToplNetworkUri(paramConfig.networkUri),
+        validateNetworkType(paramConfig.networkType)
+      ).mapN((uri, networkType) =>
+        buildNetwork(
+          uri,
+          networkType,
+          paramConfig.someApiKey
+        )
+      ),
+      validateDamlHost(paramConfig),
+      validateDamlPort(paramConfig),
+      validateFileAndPassword(paramConfig.someKeyfile, paramConfig.somePassword)
+    ).mapN((provider, damlHost, damlPort, someFileAndPassword) =>
+      CLIParamConfigValidatedInput(
+        provider,
+        damlHost,
+        damlPort,
+        someFileAndPassword
+      )
+    )
+  }
+
+  def validateFileAndPassword(
+      someFile: Option[File],
+      somePassword: Option[String]
+  ) = (someFile, somePassword) match {
+    case (Some(file), Some(password)) =>
+      Validated.validNel(Some(file, password))
+    case (Some(_), None) =>
+      Validated.invalidNel("A password is required for the keyfile")
+    case (None, Some(_)) => Validated.invalidNel("No keyfile provided")
+    case (None, None)    => Validated.validNel(None)
+  }
+
+  def validateNetworkType(networkType: String) = {
+    networkType match {
+      case "main"     => Validated.validNel("main")
+      case "valhalla" => Validated.validNel("valhalla")
+      case "private"  => Validated.validNel("private")
+      case _ =>
+        Validated.invalidNel(
+          "Invalid network type. Valid values are main, valhalla, and private"
+        )
+    }
+  }
+
+  def buildNetwork(
+      uri: Uri,
+      networkType: String,
+      someApiKey: Option[String]
+  ): Provider = {
+    networkType match {
+      case "main" =>
+        new Provider.ToplMainNet(uri, someApiKey.getOrElse(""))
+      case "valhalla" =>
+        new Provider.ValhallaTestNet(uri, someApiKey.getOrElse(""))
+      case "private" =>
+        new Provider.PrivateTestNet(uri, someApiKey.getOrElse(""))
+    }
+  }
+  def validateToplNetworkUri(networkUri: String): ValidatedNel[String, Uri] = {
+    val invalidUriMessage = "Invalid Topl network URI"
+    try {
+      Uri(networkUri) match {
+        case uri if uri.isAbsolute => Validated.validNel(uri)
+        case _                     => Validated.invalidNel(invalidUriMessage)
+      }
+    } catch {
+      case _: Throwable => Validated.invalidNel(invalidUriMessage)
+    }
+  }
+
+  def validateDamlHost(
+      paramConfig: CLIParamConfigInput
+  ): ValidatedNel[String, String] = {
+    paramConfig.damlHost match {
+      case host
+          if InetAddresses
+            .isUriInetAddress(host) || InternetDomainName.isValid(host) =>
+        Validated.validNel(host)
+      case _ => Validated.invalidNel("Invalid Daml host")
+    }
+  }
+
+  def validateDamlPort(
+      paramConfig: CLIParamConfigInput
+  ): ValidatedNel[String, Int] = {
+    paramConfig.damlPort match {
+      case port if port > 0 => Validated.validNel(port)
+      case _                => Validated.invalidNel("Invalid Daml port")
+    }
+  }
+
+}

--- a/src/main/scala/broker/PolyProcessorRegistrationModule.scala
+++ b/src/main/scala/broker/PolyProcessorRegistrationModule.scala
@@ -1,13 +1,13 @@
 package broker
 
-import io.reactivex.Flowable
+import cats.effect.IO
 import co.topl.daml.DamlAppContext
 import co.topl.daml.ToplContext
-import com.daml.ledger.javaapi.data.Transaction
-import cats.effect.IO
+import co.topl.daml.polys.processors.SignedTransferProcessor
 import co.topl.daml.polys.processors.TransferRequestProcessor
 import co.topl.daml.polys.processors.UnsignedTransferProcessor
-import co.topl.daml.polys.processors.SignedTransferProcessor
+import com.daml.ledger.javaapi.data.Transaction
+import io.reactivex.Flowable
 
 trait PolyProcessorRegistrationModule {
 

--- a/src/main/scala/broker/PolyProcessorRegistrationModule.scala
+++ b/src/main/scala/broker/PolyProcessorRegistrationModule.scala
@@ -23,8 +23,8 @@ trait PolyProcessorRegistrationModule {
           damlAppContext,
           toplContext,
           3000,
-          (x, y) => true,
-          t => true
+          (_, _) => true,
+          _ => true
         )
       )
       _ <- IO(transactions.forEach(transferProcessor.processTransaction))
@@ -63,8 +63,8 @@ trait PolyProcessorRegistrationModule {
           toplContext,
           3000,
           1,
-          (x, y) => true,
-          t => true
+          (_, _) => true,
+          _ => true
         )
       )
       _ <- IO(transactions.forEach(transferProcessor.processTransaction))

--- a/src/test/scala/broker/ParameterProcessorModuleTest.scala
+++ b/src/test/scala/broker/ParameterProcessorModuleTest.scala
@@ -1,0 +1,144 @@
+package broker
+
+import java.io.File
+
+// an m-unit test
+class ParameterProcessorModuleTest
+    extends munit.FunSuite
+    with ParameterProcessorModule {
+
+  test("Test with None keyfile and password") {
+    val input = CLIParamConfigInput(
+      networkType = "main",
+      networkUri = "https://api.topl.co",
+      someApiKey = Some("some-api-key"),
+      damlHost = "localhost",
+      damlPort = 6865,
+      someKeyfile = None,
+      somePassword = None
+    )
+
+    val validatedInput = validateParams(input)
+
+    assertEquals(validatedInput.isValid, true)
+  }
+  test("Test invalid network type") {
+    val input = CLIParamConfigInput(
+      networkType = "mainnet",
+      networkUri = "https://api.topl.co",
+      someApiKey = Some("some-api-key"),
+      damlHost = "localhost",
+      damlPort = 6865,
+      someKeyfile = None,
+      somePassword = None
+    )
+
+    val validatedInput = validateParams(input)
+
+    assertEquals(validatedInput.isInvalid, true)
+    assertEquals(
+      validatedInput.fold(_.toList, _ => Nil),
+      List("Invalid network type. Valid values are main, valhalla, and private")
+    )
+  }
+  test("Test invalid network uri") {
+    val input = CLIParamConfigInput(
+      networkType = "main",
+      networkUri = "this is an invalid uri",
+      someApiKey = Some("some-api-key"),
+      damlHost = "localhost",
+      damlPort = 6865,
+      someKeyfile = None,
+      somePassword = None
+    )
+
+    val validatedInput = validateParams(input)
+
+    assertEquals(validatedInput.isInvalid, true)
+    assertEquals(
+      validatedInput.fold(_.toList, _ => Nil),
+      List("Invalid Topl network URI")
+    )
+  }
+
+  test("Test invalid daml host") {
+    val input = CLIParamConfigInput(
+      networkType = "main",
+      networkUri = "https://api.topl.co",
+      someApiKey = Some("some-api-key"),
+      damlHost = "this is an invalid host",
+      damlPort = 6865,
+      someKeyfile = None,
+      somePassword = None
+    )
+
+    val validatedInput = validateParams(input)
+
+    assertEquals(validatedInput.isInvalid, true)
+    assertEquals(
+      validatedInput.fold(_.toList, _ => Nil),
+      List("Invalid Daml host")
+    )
+  }
+
+  test("Test invalid daml port") {
+    val input = CLIParamConfigInput(
+      networkType = "main",
+      networkUri = "https://api.topl.co",
+      someApiKey = Some("some-api-key"),
+      damlHost = "localhost",
+      damlPort = -1,
+      someKeyfile = None,
+      somePassword = None
+    )
+
+    val validatedInput = validateParams(input)
+
+    assertEquals(validatedInput.isInvalid, true)
+    assertEquals(
+      validatedInput.fold(_.toList, _ => Nil),
+      List("Invalid Daml port")
+    )
+  }
+
+  test("Test missing password") {
+    val input = CLIParamConfigInput(
+      networkType = "main",
+      networkUri = "https://api.topl.co",
+      someApiKey = Some("some-api-key"),
+      damlHost = "localhost",
+      damlPort = 6865,
+      someKeyfile = Some(new File("some-keyfile.json")),
+      somePassword = None
+    )
+
+    val validatedInput = validateParams(input)
+
+    assertEquals(validatedInput.isInvalid, true)
+    assertEquals(
+      validatedInput.fold(_.toList, _ => Nil),
+      List("A password is required for the keyfile")
+    )
+  }
+
+  test("Test missing keyfile") {
+    val input = CLIParamConfigInput(
+      networkType = "main",
+      networkUri = "https://api.topl.co",
+      someApiKey = Some("some-api-key"),
+      damlHost = "localhost",
+      damlPort = 6865,
+      someKeyfile = None,
+      somePassword = Some("some-password")
+    )
+
+    val validatedInput = validateParams(input)
+
+    assertEquals(validatedInput.isInvalid, true)
+    assertEquals(
+      validatedInput.fold(_.toList, _ => Nil),
+      List("No keyfile provided")
+    )
+  }
+
+}


### PR DESCRIPTION
## Purpose

The purpose of this PR is to add support to choose the type of Topl network that the broker is going to connect to (main, valhalla, or private).

## Approach

We have enhanced the parameter parser to use a scopt (a parameter parsing library). 

## Testing

We added unit test for the parameter validation.

## Tickets
* Topl/Brambl#138