### PR TITLE
TSDK-249 Add support for security, api tokens and customizable party

### DIFF
--- a/microsite/docs/damlhub.md
+++ b/microsite/docs/damlhub.md
@@ -1,0 +1,27 @@
+---
+sidebar_position: 2
+---
+
+# Using with DAML Hub
+
+DamlHub is a cloud-based DAML development environment. It provides a DAML sandbox and a DAML ledger as a service. The broker can be used with DamlHub to connect to the Topl network.
+
+## Prerequisites
+
+- You need to have your application contracts, triggers and UI deployed on a ledger on DamlHub. To launch the broker we will need the ledger ID which we refer to as `<ledger id>`.
+- You need to have the ledger host on DamlHub. This is usually the ledger ID followed by `.daml.app`.
+- You need to create a Service User and use the login WS to obtain its access token (see [DamlHub documentation](https://hub.daml.com/docs/api/#operation/saLogin) for more details). To launch the broker we need this token, which we refer to as `<access token>`.
+- You need to extract the party for the UserAdmin party from DAML Hub UI. To launch the broker we need this party, which we refer to as `<user admin party>`.
+- For this documentation we assume that you are running your bifrost node locally on port 9085. To use another network, the parameters need to be adapted accordingly.
+- DAML Hub is secured using TLS, thus we need to enable the TLS flag when launching the broker `-s true`.
+
+
+### Launch the broker
+
+Assuming your `keyfile.json` in the current directory and its password is `test` you can launch the broker using the following command (this uses coursier to launch it):
+
+```bash
+cs launch co.topl:bifrost-daml-broker_2.13:0.2.0 --  -n private -u http://127.0.0.1:9085 -h <ledger id>.daml.app -p 443 -s true -t "<access token>" -o "<user admin party>" -k keyfile.json -w test
+```
+
+

--- a/microsite/docs/intro.md
+++ b/microsite/docs/intro.md
@@ -25,6 +25,28 @@ to run Java applications without any setup. It is very easy to install.
 
 To launch the broker you need to provide it with a `keyfile.json` file and the password for that file.
 
+###  Initializing the DAML Ledger
+
+Before launching the broker you need to initialize the DAML ledger. For this, your ledger initialization script
+needs to allocate a party for the broker. The broker will use this party to interact with the ledger.
+
+This can be done by adding the following line to your DAML initialization script:
+
+```daml
+import Daml.Script
+import DA.Optional
+
+initialize : Script [Party]
+initialize = do
+    broker <- allocateParty "broker"
+    brokerId <- validateUserId "broker"
+    createUser (Daml.Script.User brokerId (Some broker)) [CanActAs broker]
+    debug ("broker party: " <> partyToText broker)
+    pure []
+```
+
+The debug statement will print the party allocated for the broker. You will need this party to launch the broker.
+
 ### Launch the Prerequirements
 
 You need to launch the DAML sandbox from your DAML project using the following command:
@@ -44,6 +66,6 @@ docker run -p 9085:9085 toplprotocol/bifrost-node:1.10.2 --forge --disableAuth -
 Assuming your `keyfile.json` in the current directory and its password is `test` you can launch the broker using the following command (this uses coursier to launch it):
 
 ```bash
-cs launch co.topl:bifrost-daml-broker_2.13:0.1.1 -- 127.0.0.1 6865 keyfile.json test
+cs launch co.topl:bifrost-daml-broker_2.13:0.2.0 --  -n private -u http://127.0.0.1:9085 -h localhost -p 6865 -s false -o <broker party> -k keyfile.json -w test
 ```
 

--- a/microsite/docs/reference/_category_.json
+++ b/microsite/docs/reference/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Reference",
-  "position": 2,
+  "position": 3,
   "link": {
     "type": "generated-index",
     "description": "Some references to learn more about the bifrost-daml-broker."

--- a/microsite/docs/reference/runtime.md
+++ b/microsite/docs/reference/runtime.md
@@ -13,6 +13,7 @@ We need the following parameters to launch the broker.
 ### Example
 
 ```bash
+bifrost-daml-broker 0.2
 Usage: bifrost-daml-broker [options]
 
   -n, --topl-network <value>
@@ -22,6 +23,14 @@ Usage: bifrost-daml-broker [options]
                            the API key for the Topl network
   -h, --daml-host <value>  the host of the ledger, for example localhost
   -p, --daml-port <value>  the port where the ledger is listening, for example 6865
+  -s, --daml-security-enabled <value>
+                           whether to use TLS for the connection to the ledger
+  -t, --daml-access-token <value>
+                           the access token for the ledger
+  -t, --daml-application-id <value>
+                           the application id for the ledger, for DAML Hub hosted application the right value is 'damlhub', which is the default value when omitted
+  -o, --daml-operator-party <value>
+                           the party that will be used to submit transactions to the ledger
   -k, --keyfile <value>    the file that contains the operator key, for example keyfile.json
   -w, --password <value>   the password for the keyfile
 ```
@@ -45,6 +54,23 @@ The host of the ledger, for example localhost.
 ### -p, --daml-port <value\>
 
 The port where the ledger is listening, for example 6865.
+
+
+### -s, --daml-security-enabled <value\>
+
+Whether to use TLS for the connection to the ledger. Possible values are `true` and `false`.
+
+### -t, --daml-access-token <value\>
+
+When the ledger is secured, this is the access token to access the Ledger API.
+
+### -t, --daml-application-id <value\>
+
+The application id for the ledger, for DAML Hub hosted application the right value is 'damlhub', which is the default value when this parameter is omitted.
+
+### -o, --daml-operator-party <value\>
+
+The party that will be used to submit and read transactions from the ledger.
 
 ### -k, --keyfile <value\>
 

--- a/microsite/docusaurus.config.js
+++ b/microsite/docusaurus.config.js
@@ -67,6 +67,12 @@ const config = {
           },
           {
             type: 'doc',
+            docId: 'damlhub',
+            position: 'left',
+            label: 'Using with DAMLHub',
+          },
+          {
+            type: 'doc',
             docId: '/category/reference',
             position: 'left',
             label: 'Reference',

--- a/src/main/scala/broker/BrokerMain.scala
+++ b/src/main/scala/broker/BrokerMain.scala
@@ -24,8 +24,6 @@ object BrokerMain
     with BalanceProcessorModule
     with ParameterProcessorModule {
 
-  val APP_ID = "damlhub";
-
   def runWithParams(paramConfig: CLIParamConfigValidatedInput) = {
     (for {
       client <- createClient(
@@ -36,7 +34,7 @@ object BrokerMain
       )
       _ <- connect(client)
       operatorParty <- IO(paramConfig.damlOperatorParty)
-      damlAppContext <- IO(new DamlAppContext(APP_ID, operatorParty, client))
+      damlAppContext <- IO(new DamlAppContext(paramConfig.damlApplicationId, operatorParty, client))
       toplContext <- IO(
         new ToplContext(
           ActorSystem(),

--- a/src/main/scala/broker/BrokerMain.scala
+++ b/src/main/scala/broker/BrokerMain.scala
@@ -10,11 +10,10 @@ import cats.effect.IOApp
 import co.topl.daml.DamlAppContext
 import co.topl.daml.ToplContext
 import com.daml.ledger.javaapi.data.FiltersByParty
-import com.daml.ledger.javaapi.data.GetUserRequest
 import com.daml.ledger.javaapi.data.LedgerOffset
 import com.daml.ledger.javaapi.data.NoFilter
 import com.daml.ledger.rxjava.DamlLedgerClient
-import com.daml.ledger.rxjava.UserManagementClient
+import io.grpc.netty.GrpcSslContexts
 import scopt.OParser
 
 object BrokerMain
@@ -25,16 +24,18 @@ object BrokerMain
     with BalanceProcessorModule
     with ParameterProcessorModule {
 
-  val OPERATOR_USER = "public";
   val APP_ID = "toplBrokerApp";
-
 
   def runWithParams(paramConfig: CLIParamConfigValidatedInput) = {
     (for {
-      client <- createClient(paramConfig.damlHost, paramConfig.damlPort)
+      client <- createClient(
+        paramConfig.damlHost,
+        paramConfig.damlPort,
+        paramConfig.damlSecurityEnabled,
+        paramConfig.damlAccessToken
+      )
       _ <- connect(client)
-      userManagementClient <- getUserManagementClient(client)
-      operatorParty <- getOperatorParty(userManagementClient)
+      operatorParty <- IO(paramConfig.damlOperatorParty)
       damlAppContext <- IO(new DamlAppContext(APP_ID, operatorParty, client))
       toplContext <- IO(
         new ToplContext(
@@ -74,7 +75,11 @@ object BrokerMain
           case Validated.Valid(validatedInput) =>
             runWithParams(validatedInput)
           case Validated.Invalid(errors) =>
-            IO.println("The broker was launched with invalid parameters:\n" + errors.toList.map(s => " - " + s).mkString("\n")) *>
+            IO.println(
+              "The broker was launched with invalid parameters:\n" + errors.toList
+                .map(s => " - " + s)
+                .mkString("\n")
+            ) *>
               IO.pure(ExitCode.Error)
         }
       case None =>
@@ -95,22 +100,28 @@ object BrokerMain
       )
   )
 
-  def getOperatorParty(userManagementClient: UserManagementClient) = for {
-    getUserResponse <- IO.blocking(
-      userManagementClient
-        .getUser(new GetUserRequest(OPERATOR_USER))
-        .blockingGet()
-    )
-  } yield getUserResponse.getUser().getPrimaryParty().get()
+  def createClient(
+      host: String,
+      port: Int,
+      damlSecurityEnabled: Boolean,
+      damlAccessToken: Option[String]
+  ) = IO {
 
-  def getUserManagementClient(client: DamlLedgerClient) =
-    IO(client.getUserManagementClient())
+    val enableSecurity: DamlLedgerClient.Builder => DamlLedgerClient.Builder =
+      (if (damlSecurityEnabled)
+         _.withSslContext(GrpcSslContexts.forClient().build())
+       else identity _)
+    val enableAccessToken
+        : DamlLedgerClient.Builder => DamlLedgerClient.Builder =
+      damlAccessToken
+        .map(x => (y: DamlLedgerClient.Builder) => y.withAccessToken(x))
+        .getOrElse(identity _)
 
-  def createClient(host: String, port: Int) = IO(
-    DamlLedgerClient.newBuilder(host, port).build()
-  )
+    enableSecurity
+      .compose(enableAccessToken)(DamlLedgerClient.newBuilder(host, port))
+      .build()
+  }
 
   def connect(client: DamlLedgerClient) = IO(client.connect())
-
 
 }

--- a/src/main/scala/broker/BrokerMain.scala
+++ b/src/main/scala/broker/BrokerMain.scala
@@ -24,7 +24,7 @@ object BrokerMain
     with BalanceProcessorModule
     with ParameterProcessorModule {
 
-  val APP_ID = "toplBrokerApp";
+  val APP_ID = "damlhub";
 
   def runWithParams(paramConfig: CLIParamConfigValidatedInput) = {
     (for {

--- a/src/main/scala/broker/CLIParamConfig.scala
+++ b/src/main/scala/broker/CLIParamConfig.scala
@@ -13,6 +13,7 @@ case class CLIParamConfigInput(
     damlSecurityEnabled: Boolean = false,
     damlAccessToken: Option[String] = None,
     damlOperatorParty: String = "",
+    damlApplicationId: Option[String] = None,
     someKeyfile: Option[File] = None,
     somePassword: Option[String] = None
 )
@@ -24,5 +25,6 @@ case class CLIParamConfigValidatedInput(
     damlSecurityEnabled: Boolean,
     damlAccessToken: Option[String],
     damlOperatorParty: String,
+    damlApplicationId: String,
     keyfileAndPassword: Option[(File, String)]
 )

--- a/src/main/scala/broker/CLIParamConfig.scala
+++ b/src/main/scala/broker/CLIParamConfig.scala
@@ -10,6 +10,9 @@ case class CLIParamConfigInput(
     someApiKey: Option[String] = None,
     damlHost: String = "",
     damlPort: Int = 0,
+    damlSecurityEnabled: Boolean = false,
+    damlAccessToken: Option[String] = None,
+    damlOperatorParty: String = "",
     someKeyfile: Option[File] = None,
     somePassword: Option[String] = None
 )
@@ -18,5 +21,8 @@ case class CLIParamConfigValidatedInput(
     provider: Provider,
     damlHost: String,
     damlPort: Int,
+    damlSecurityEnabled: Boolean,
+    damlAccessToken: Option[String],
+    damlOperatorParty: String,
     keyfileAndPassword: Option[(File, String)]
 )

--- a/src/main/scala/broker/ParameterProcessorModule.scala
+++ b/src/main/scala/broker/ParameterProcessorModule.scala
@@ -44,6 +44,9 @@ trait ParameterProcessorModule {
       opt[Option[String]]('t', "daml-access-token")
         .action((x, c) => c.copy(damlAccessToken = x))
         .text("the access token for the ledger"),
+      opt[Option[String]]('t', "daml-application-id")
+        .action((x, c) => c.copy(damlApplicationId = x))
+        .text("the application id for the ledger, for DAML Hub hosted application the right value is 'damlhub', which is the default value when omitted"),
       opt[String]('o', "daml-operator-party")
         .action((x, c) => c.copy(damlOperatorParty = x))
         .text("the party that will be used to submit transactions to the ledger"),
@@ -80,6 +83,7 @@ trait ParameterProcessorModule {
         paramConfig.damlSecurityEnabled,
         paramConfig.damlAccessToken,
         damlOperatorParty,
+        paramConfig.damlApplicationId.getOrElse("damlhub"),
         someFileAndPassword
       )
     )

--- a/src/main/scala/broker/ParameterProcessorModule.scala
+++ b/src/main/scala/broker/ParameterProcessorModule.scala
@@ -38,6 +38,15 @@ trait ParameterProcessorModule {
       opt[Option[File]]('k', "keyfile")
         .action((x, c) => c.copy(someKeyfile = x))
         .text("the file that contains the operator key, for example keyfile.json"),
+      opt[Boolean]('s', "daml-security-enabled")
+        .action((x, c) => c.copy(damlSecurityEnabled = x))
+        .text("whether to use TLS for the connection to the ledger"),	
+      opt[Option[String]]('t', "daml-access-token")
+        .action((x, c) => c.copy(damlAccessToken = x))
+        .text("the access token for the ledger"),
+      opt[String]('o', "daml-operator-party")
+        .action((x, c) => c.copy(damlOperatorParty = x))
+        .text("the party that will be used to submit transactions to the ledger"),
       opt[Option[String]]('w', "password")
         .action((x, c) => c.copy(somePassword = x))
         .text("the password for the keyfile")
@@ -61,15 +70,26 @@ trait ParameterProcessorModule {
       ),
       validateDamlHost(paramConfig),
       validateDamlPort(paramConfig),
+      validateDamlOperatorParty(paramConfig.damlOperatorParty),
       validateFileAndPassword(paramConfig.someKeyfile, paramConfig.somePassword)
-    ).mapN((provider, damlHost, damlPort, someFileAndPassword) =>
+    ).mapN((provider, damlHost, damlPort, damlOperatorParty, someFileAndPassword) =>
       CLIParamConfigValidatedInput(
         provider,
         damlHost,
         damlPort,
+        paramConfig.damlSecurityEnabled,
+        paramConfig.damlAccessToken,
+        damlOperatorParty,
         someFileAndPassword
       )
     )
+  }
+
+  def validateDamlOperatorParty(damlOperatorParty: String) = {
+    damlOperatorParty match {
+      case "" => Validated.invalidNel("No operator party provided")
+      case _  => Validated.validNel(damlOperatorParty)
+    }
   }
 
   def validateFileAndPassword(

--- a/src/test/scala/broker/ParameterProcessorModuleTest.scala
+++ b/src/test/scala/broker/ParameterProcessorModuleTest.scala
@@ -14,6 +14,7 @@ class ParameterProcessorModuleTest
       someApiKey = Some("some-api-key"),
       damlHost = "localhost",
       damlPort = 6865,
+      damlOperatorParty = "party::abcdefg",
       someKeyfile = None,
       somePassword = None
     )
@@ -29,6 +30,7 @@ class ParameterProcessorModuleTest
       someApiKey = Some("some-api-key"),
       damlHost = "localhost",
       damlPort = 6865,
+      damlOperatorParty = "party::abcdefg",
       someKeyfile = None,
       somePassword = None
     )
@@ -48,6 +50,7 @@ class ParameterProcessorModuleTest
       someApiKey = Some("some-api-key"),
       damlHost = "localhost",
       damlPort = 6865,
+      damlOperatorParty = "party::abcdefg",
       someKeyfile = None,
       somePassword = None
     )
@@ -68,6 +71,7 @@ class ParameterProcessorModuleTest
       someApiKey = Some("some-api-key"),
       damlHost = "this is an invalid host",
       damlPort = 6865,
+      damlOperatorParty = "party::abcdefg",
       someKeyfile = None,
       somePassword = None
     )
@@ -88,6 +92,7 @@ class ParameterProcessorModuleTest
       someApiKey = Some("some-api-key"),
       damlHost = "localhost",
       damlPort = -1,
+      damlOperatorParty = "party::abcdefg",
       someKeyfile = None,
       somePassword = None
     )
@@ -108,6 +113,7 @@ class ParameterProcessorModuleTest
       someApiKey = Some("some-api-key"),
       damlHost = "localhost",
       damlPort = 6865,
+      damlOperatorParty = "party::abcdefg",
       someKeyfile = Some(new File("some-keyfile.json")),
       somePassword = None
     )
@@ -128,6 +134,7 @@ class ParameterProcessorModuleTest
       someApiKey = Some("some-api-key"),
       damlHost = "localhost",
       damlPort = 6865,
+      damlOperatorParty = "party::abcdefg",
       someKeyfile = None,
       somePassword = Some("some-password")
     )
@@ -140,5 +147,28 @@ class ParameterProcessorModuleTest
       List("No keyfile provided")
     )
   }
+  
+  test("Invalid party") {
+    val input = CLIParamConfigInput(
+      networkType = "main",
+      networkUri = "https://api.topl.co",
+      someApiKey = Some("some-api-key"),
+      damlHost = "localhost",
+      damlPort = 6865,
+      damlOperatorParty = "",
+      someKeyfile = None,
+      somePassword = None
+    )
+
+    val validatedInput = validateParams(input)
+
+    assertEquals(validatedInput.isInvalid, true)
+    assertEquals(
+      validatedInput.fold(_.toList, _ => Nil),
+      List("No operator party provided")
+    )
+  }
+
+
 
 }


### PR DESCRIPTION
## Purpose

The goal of this PR is to add support to connect to DAML hub to the broker.

## Approach

To add broker support several steps had to be performed:

- A DAML app was deployed to the ledger
- The broker was modified to be able to connect to the ledger

The connection to the ledger required new configuration. Thus new command line parameters were added to the broker.

## Testing

Unit tests were added for the validations of the parameters. The broker was tested with the daml hub app.

## Tickets
* Topl/Brambl#136
